### PR TITLE
options to specify the numbers of worker processes

### DIFF
--- a/lib/graceful-cluster.js
+++ b/lib/graceful-cluster.js
@@ -36,6 +36,7 @@ GracefulCluster.start = function(options) {
     var log = options.log || console.log;
     var shutdownTimeout = options.shutdownTimeout || 5000;
     var disableGraceful = options.disableGraceful;
+    var workers = options.workers || numCPUs;
 
     if (cluster.isMaster) {
 
@@ -47,7 +48,7 @@ GracefulCluster.start = function(options) {
         // Prevent killing all workers at same time when restarting.
         function checkRestartQueue() {
             // Kill one worker only if maximum count are working.
-            if (restartQueue.length > 0 && listeningWorkersCount === numCPUs) {
+            if (restartQueue.length > 0 && listeningWorkersCount === workers) {
                 var pid = restartQueue.shift();
                 try {
                     // Send SIGTERM signal to worker. SIGTERM starts graceful shutdown of worker inside it.
@@ -73,7 +74,7 @@ GracefulCluster.start = function(options) {
         }
 
         // Fork workers.
-        for (var i = 0; i < numCPUs; i++) {
+        for (var i = 0; i < workers; i++) {
             fork();
         }
 


### PR DESCRIPTION
For saving of server resources, I want to specify the numbers of worker process.
In this request, the numbers of worker processes is specified by the argument for GracefulCluster.start().
The default values is original value (the number of CPUs).
please pull them if acceptable.