### PR TITLE
Clear timeouts when exiting so we don't leave garbage behind

### DIFF
--- a/lib/graceful-cluster.js
+++ b/lib/graceful-cluster.js
@@ -42,11 +42,12 @@ GracefulCluster.start = function(options) {
 
     if (cluster.isMaster) {
 
-        var sigkill = false;
+        var currentRestartingPid = null;
         var currentWorkersCount = 0;
         var listeningWorkersCount = 0;
         var restartQueue = [];
-        var currentRestartingPid = null;
+        var shutdownTimer = null;
+        var sigkill = false;
 
         // Prevent killing all workers at same time when restarting.
         function checkRestartQueue() {
@@ -95,6 +96,7 @@ GracefulCluster.start = function(options) {
         function checkIfNoWorkersAndExit() {
             if (!currentWorkersCount) {
                 log('Cluster graceful shutdown: done.');
+                if (shutdownTimer) clearTimeout(shutdownTimer);
                 exitFunction();
             } else {
                 log('Cluster graceful shutdown: wait ' + currentWorkersCount + ' worker' + (currentWorkersCount > 1 ? 's' : '') + '.');
@@ -104,6 +106,7 @@ GracefulCluster.start = function(options) {
         function startShutdown() {
 
             if (disableGraceful) {
+                if (shutdownTimer) clearTimeout(shutdownTimer);
                 exitFunction();
                 return;
             }
@@ -116,7 +119,7 @@ GracefulCluster.start = function(options) {
             }
 
             // Shutdown timeout.
-            setTimeout(function() {
+            shutdownTimer = setTimeout(function() {
                 log('Cluster graceful shutdown: timeout, force exit.');
                 exitFunction();
             }, shutdownTimeout);

--- a/lib/graceful-server.js
+++ b/lib/graceful-server.js
@@ -10,6 +10,7 @@ var GracefulServer = function(options) {
 
     this.log = options.log || console.log;
     this.shutdownTimeout = options.shutdownTimeout || 5000;
+    this._shutdownTimer = null;
 
     // Solution got from: https://github.com/nodejs/node-v0.x-archive/issues/9066#issuecomment-124210576
 
@@ -66,13 +67,14 @@ GracefulServer.prototype.shutdown = function() {
 
     var that = this;
 
-    setTimeout(function() {
+    this._shutdownTimer = setTimeout(function() {
         that.log('pid:' + process.pid + ' graceful shutdown: timeout, force exit.');
         process.exit(0);
     }, this.shutdownTimeout);
 
     this.server.close(function() {
         that.log('pid:' + process.pid + ' graceful shutdown: done.');
+        if (that._shutdownTimer) clearTimeout(that._shutdownTimer);
         process.exit(0);
     });
 


### PR DESCRIPTION
Sorry for following up with another PR so quickly after you bumped the version!

When exiting, the timeouts weren't being cleared. This is normally a non-issue when we're just `process.exit(0)`'ing, but I'm not actually doing that. In all cases, garbage is left behind and then `process.exit(0)` lets the OS clean it up. In the case where you do something other than exit, the timer would still eventually fire even though it already gracefully exited and we should prevent that condition. Also, clearing this timeout lets Node exit on its own since I clean up all of the other timers in our app through some miracle :).